### PR TITLE
BugFix - ChildProcess - handle large amount of output in spawnSync

### DIFF
--- a/test/Rench_Test/ChildProcessSpawnTest.re
+++ b/test/Rench_Test/ChildProcessSpawnTest.re
@@ -126,9 +126,9 @@ describe("ChildProcess", ({test, describe}) => {
 
     test("handles large amounts of output", ({expect}) => {
       let script = {|
-            const ITERATIONS = 500001;
+            const ITERATIONS = 1000001;
             for (let i = 0; i < ITERATIONS; i++) {
-                console.log("WRITING LINE: |" + i.toString() + "|");
+                console.log("WRITING LINE: --------|" + i.toString() + "|--------");
             }
           |};
 
@@ -138,12 +138,10 @@ describe("ChildProcess", ({test, describe}) => {
 
       let str = String.split_on_char('\n', out);
 
-      let last = str
-      |> List.rev
-      |> List.hd;
+      let last = str |> List.rev |> List.hd;
 
-      expect.string(last).toEqual("WRITING LINE: |500000|");
-      expect.int(List.length(str)).toBe(500001);
-    })
+      expect.string(last).toEqual("WRITING LINE: --------|1000000|--------");
+      expect.int(List.length(str)).toBe(1000001);
+    });
   });
 });

--- a/test/Rench_Test/ChildProcessSpawnTest.re
+++ b/test/Rench_Test/ChildProcessSpawnTest.re
@@ -136,11 +136,14 @@ describe("ChildProcess", ({test, describe}) => {
         ChildProcess.spawnSync("node", [|"-e", script|])
         |> (p => p.stdout |> String.trim);
 
-      let last = String.split_on_char('\n', out)
+      let str = String.split_on_char('\n', out);
+
+      let last = str
       |> List.rev
       |> List.hd;
 
       expect.string(last).toEqual("WRITING LINE: |500000|");
+      expect.int(List.length(str)).toBe(500001);
     })
   });
 });

--- a/test/Rench_Test/ChildProcessSpawnTest.re
+++ b/test/Rench_Test/ChildProcessSpawnTest.re
@@ -123,5 +123,24 @@ describe("ChildProcess", ({test, describe}) => {
 
       expect.string(out).toEqual("0451");
     });
+
+    test("handles large amounts of output", ({expect}) => {
+      let script = {|
+            const ITERATIONS = 500001;
+            for (let i = 0; i < ITERATIONS; i++) {
+                console.log("WRITING LINE: |" + i.toString() + "|");
+            }
+          |};
+
+      let out =
+        ChildProcess.spawnSync("node", [|"-e", script|])
+        |> (p => p.stdout |> String.trim);
+
+      let last = String.split_on_char('\n', out)
+      |> List.rev
+      |> List.hd;
+
+      expect.string(last).toEqual("WRITING LINE: |500000|");
+    })
   });
 });


### PR DESCRIPTION
For large amounts of output, the `stdout` value would be truncated upon return from `ChildProcess.spawnSync`. This fixes the issue - making sure we flush the buffer at the end - and adds a test case to exercise the large-stdout case.
