### PR TITLE
Add stderr to ChildProcess.

### DIFF
--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -40,42 +40,42 @@ let _withWorkingDirectory = (wd: option(string), f) => {
 };
 
 let createReadingThread = (pipe, pipe_onData, isRunning) =>
-    Thread.create(
-      ((pipe, pipe_onData)) => {
-        let buffer = Buffer.create(8192);
-        let bytes = Bytes.create(8192);
+  Thread.create(
+    ((pipe, pipe_onData)) => {
+      let buffer = Buffer.create(8192);
+      let bytes = Bytes.create(8192);
 
-        let isReading = ref(true);
+      let isReading = ref(true);
 
-        let flush = () => {
-          let out = Buffer.to_bytes(buffer);
-          Buffer.clear(buffer);
-          Event.dispatch(pipe_onData, out);
-        };
+      let flush = () => {
+        let out = Buffer.to_bytes(buffer);
+        Buffer.clear(buffer);
+        Event.dispatch(pipe_onData, out);
+      };
 
-        while (isReading^) {
-          let ready = Thread.wait_timed_read(pipe, 0.01);
-          if (ready) {
-            let n = Unix.read(pipe, bytes, 0, 8192);
+      while (isReading^) {
+        let ready = Thread.wait_timed_read(pipe, 0.01);
+        if (ready) {
+          let n = Unix.read(pipe, bytes, 0, 8192);
 
-            if (n > 0) {
-              let sub = Bytes.sub(bytes, 0, n);
-              Buffer.add_bytes(buffer, sub);
+          if (n > 0) {
+            let sub = Bytes.sub(bytes, 0, n);
+            Buffer.add_bytes(buffer, sub);
 
-              if (n < 8192) {
-                flush();
-              };
-            } else if (! isRunning^) {
-              if (Buffer.length(buffer) > 0) {
-                flush();
-              };
-              isReading := false;
+            if (n < 8192) {
+              flush();
             };
+          } else if (! isRunning^) {
+            if (Buffer.length(buffer) > 0) {
+              flush();
+            };
+            isReading := false;
           };
         };
-      },
-      (pipe, pipe_onData),
-    );
+      };
+    },
+    (pipe, pipe_onData),
+  );
 
 let _spawn =
     (
@@ -105,7 +105,7 @@ let _spawn =
         formattedEnv,
         pstdin,
         pstdout,
-        pstderr
+        pstderr,
       )
     );
 
@@ -240,6 +240,11 @@ let spawnSync =
     | None => (-1)
     };
 
-  let ret: processSync = {pid: innerProc.pid, stdout: outOutput^, stderr: errOutput^, exitCode};
+  let ret: processSync = {
+    pid: innerProc.pid,
+    stdout: outOutput^,
+    stderr: errOutput^,
+    exitCode,
+  };
   ret;
 };

--- a/src/ChildProcessTypes.re
+++ b/src/ChildProcessTypes.re
@@ -12,6 +12,7 @@ type process = {
   pid: int,
   stdout: outputPipe,
   stdin: inputPipe,
+  stderr: outputPipe,
   onClose: Event.t(int),
   exitCode: ref(option(int)),
 };
@@ -20,6 +21,7 @@ type processSync = {
   pid: int,
   exitCode: int,
   stdout: string,
+  stderr: string,
 };
 
 module SpawnSyncOptions = {

--- a/test/Rench_Test/ChildProcessSpawnTest.re
+++ b/test/Rench_Test/ChildProcessSpawnTest.re
@@ -62,7 +62,7 @@ describe("ChildProcess", ({test, describe, _}) => {
 
     let formattedData = Str.split(Str.regexp("\n"), data^)
 
-    /* Check that we got _some_ version */
+    /* Check we got the expected error message */
     expect.list(formattedData).toEqual(expectedOutput);
 
     switch (proc.exitCode^) {

--- a/test/Rench_Test/ChildProcessSpawnTest.re
+++ b/test/Rench_Test/ChildProcessSpawnTest.re
@@ -82,23 +82,23 @@ describe("ChildProcess", ({describe, _}) => {
     });
   });
 
-  describe("stderr", ({test, _}) => {
-      test("spawn with output to stderr", ({expect}) => {
-        let script = {|
+  describe("stderr", ({test, _}) =>
+    test("spawn with output to stderr", ({expect}) => {
+      let script = {|
             console.error('error output');
         |};
-        let proc = ChildProcess.spawn("node", [|"-e", script|]);
+      let proc = ChildProcess.spawn("node", [|"-e", script|]);
 
-        let data = ref("");
-        let _ =
-          Event.subscribe(proc.stderr.onData, str =>
-            data := data^ ++ Bytes.to_string(str)
-          );
+      let data = ref("");
+      let _ =
+        Event.subscribe(proc.stderr.onData, str =>
+          data := data^ ++ Bytes.to_string(str)
+        );
 
-        waitForProcessExit(proc);
-        expect.string(data^).toEqual("error output\n");
-      });
-  });
+      waitForProcessExit(proc);
+      expect.string(data^).toEqual("error output\n");
+    })
+  );
 
   describe("spawnSync", ({test, _}) => {
     test("process creation", ({expect}) => {


### PR DESCRIPTION
Been messing with some stuff that launches processes and was using Rench, and realised that since the stderr isn't hooked up, it leaks to the terminal.

Potentially also useful for some bits to check why commands errored.