### PR TITLE
API: Add 'process.pid' function with correct behavior on Windows

### DIFF
--- a/src/Process.re
+++ b/src/Process.re
@@ -3,9 +3,6 @@
  * See: https://github.com/ocaml/ocaml/issues/4034
  */
 
-external _win32_pid: unit => unit = "rench_win32_pid";
+external _rench_pid: int => int = "rench_pid";
 
-let pid = () => switch(Sys.win32) {
-    | true => _win32_pid();
-    | false => Unix.getpid();
-};
+let pid = () => _rench_pid(Unix.getpid());

--- a/src/Process.re
+++ b/src/Process.re
@@ -1,0 +1,11 @@
+/* 
+ * Unix.getpid() on Windows doesn't return the expected result...
+ * See: https://github.com/ocaml/ocaml/issues/4034
+ */
+
+external _win32_pid: unit => unit = "rench_win32_pid";
+
+let pid = () => switch(Sys.win32) {
+    | true => _win32_pid();
+    | false => Unix.getpid();
+};

--- a/src/Process.rei
+++ b/src/Process.rei
@@ -1,0 +1,7 @@
+/*
+ * Process
+ *
+ * Module for cross-platform functionality related to the running process
+ */
+
+let pid = unit => int;

--- a/src/Process.rei
+++ b/src/Process.rei
@@ -4,4 +4,4 @@
  * Module for cross-platform functionality related to the running process
  */
 
-let pid = unit => int;
+let pid: unit => int;

--- a/src/Rench.re
+++ b/src/Rench.re
@@ -4,3 +4,4 @@ module Environment = Environment;
 module EnvironmentVariables = EnvironmentVariables;
 module Event = Event;
 module Path = Path;
+module Process = Process;

--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,5 @@
     (name Rench)
     (public_name Rench)
     (flags (:standard -w -21))
+    (c_names process)
     (libraries fpath lwt lwt.unix console.lib))

--- a/src/process.c
+++ b/src/process.c
@@ -13,8 +13,8 @@ value rench_pid(value handle) {
 
 #ifdef _WIN32
     HANDLE hnd = (HANDLE)Long_val(handle);
-    CAMLreturn(Val_int(GetProcessId(hdn));
+    CAMLreturn(Val_int(GetProcessId(hnd)));
 #else
-    CAMLreturn(handle);)    
+    CAMLreturn(handle);    
 #endif
 }

--- a/src/process.c
+++ b/src/process.c
@@ -1,0 +1,20 @@
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+/* This fix inspired by:
+ * https://github.com/facebook/flow/blob/276bb7f60e3f2fe2646cc7c77badf7086463e761/hack/utils/sysinfo.c
+ */
+value rench_pid(value handle) {
+    CAMLparam1(handle);
+
+#ifdef _WIN32
+    HANDLE hnd = (HANDLE)Long_val(handle);
+    CAMLreturn(Val_int(GetProcessId(hdn));
+#else
+    CAMLreturn(handle);)    
+#endif
+}


### PR DESCRIPTION
__Issue:__ On Windows, the `Unix.getpid()` method returns the _process handle_ instead of the _process ID_.

__Fix:__ Trade in the handle for the process ID. This is important when integrating with other APIs that expect an actual process id.