### PR TITLE
Bugfix: Ignore write fail

### DIFF
--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -185,14 +185,7 @@ let _spawn =
     _errThread: errThread,
   };
 
-  let _ =
-    Event.subscribe(
-      onClose,
-      code => {
-        prerr_endline("RENCH: ONCLOSE");
-        ret.exitCode := Some(code);
-      },
-    );
+  let _ = Event.subscribe(onClose, code => ret.exitCode := Some(code));
 
   ret;
 };

--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -151,15 +151,13 @@ let _spawn =
   };
 
   let stdinWrite = bytes => {
-    switch(
-    Unix.write(stdin, bytes, 0, Bytes.length(bytes))
-    ) {
+    switch (Unix.write(stdin, bytes, 0, Bytes.length(bytes))) {
     /* A write may fail expectedly if the process was closed internally.
        In that case, the write channel will be invalid prior to us
        getting a close event - so we should just ignore it. */
-    | exception Unix.Unix_error(_) => ()
+    | exception (Unix.Unix_error(_)) => ()
     | _ => ()
-    }
+    };
   };
 
   let retStdin: inputPipe = {write: stdinWrite, close: stdinClose};
@@ -187,10 +185,14 @@ let _spawn =
     _errThread: errThread,
   };
 
-  let _ = Event.subscribe(onClose, code => {
-      prerr_endline ("RENCH: ONCLOSE");
-      ret.exitCode := Some(code);
-  });
+  let _ =
+    Event.subscribe(
+      onClose,
+      code => {
+        prerr_endline("RENCH: ONCLOSE");
+        ret.exitCode := Some(code);
+      },
+    );
 
   ret;
 };

--- a/test/Rench_Test/TestFramework.re
+++ b/test/Rench_Test/TestFramework.re
@@ -1,4 +1,7 @@
 include Rely.Make({
   let config =
-    Rely.TestFrameworkConfig.initialize({snapshotDir: "./__snapshots__", projectDir: "."});
+    Rely.TestFrameworkConfig.initialize({
+      snapshotDir: "./__snapshots__",
+      projectDir: ".",
+    });
 });


### PR DESCRIPTION
__Issue:__ In Onivim 2, when we close the Neovim process via `:q!`, occassionally we'd get an exception bubble up from `stdinWrite`.

__Defect:__ In the case where a process closes itself, we may not get a notification of `onClose` until we fail to write (in other words, the write failure may happen first).

__Fix:__ Ignore write failure - in my testing so far, this exception only occurs on process close. Would be interested to see if there is a more robust way to handle this.