### PR TITLE
Bugfix: Pipe closed too early

### DIFF
--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -162,7 +162,7 @@ let _spawn =
 
   let retStdin: inputPipe = {write: stdinWrite, close: stdinClose};
 
-  let kill = sig_ => {
+  let kill = sig_ =>
     if (isRunning^) {
       let signalToUse =
         Sys.win32
@@ -171,12 +171,11 @@ let _spawn =
 
       /* In some cases, we get a Unix_error(Unix.ESRCH, "kill") exception thrown */
       /* For now - just ignore. Is there a case where the consumer needs to know / handle this? */
-      switch(Unix.kill(pid, signalToUse)) {
+      switch (Unix.kill(pid, signalToUse)) {
       | exception (Unix.Unix_error(_)) => ()
       | _ => ()
       };
-    }
-  };
+    };
 
   let ret: innerProcess = {
     pid,

--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -162,15 +162,21 @@ let _spawn =
 
   let retStdin: inputPipe = {write: stdinWrite, close: stdinClose};
 
-  let kill = sig_ =>
+  let kill = sig_ => {
     if (isRunning^) {
       let signalToUse =
         Sys.win32
           ? Sys.sigkill  /* Sigkill is the only signal supported on Win by the Unix module */
           : sig_;
 
-      Unix.kill(pid, signalToUse);
-    };
+      /* In some cases, we get a Unix_error(Unix.ESRCH, "kill") exception thrown */
+      /* For now - just ignore. Is there a case where the consumer needs to know / handle this? */
+      switch(Unix.kill(pid, signalToUse)) {
+      | exception (Unix.Unix_error(_)) => ()
+      | _ => ()
+      };
+    }
+  };
 
   let ret: innerProcess = {
     pid,

--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -70,7 +70,13 @@ let createReadingThread = (pipe, pipe_onData, isRunning) =>
           | v => v
           };
         if (ready) {
-          let n = Unix.read(pipe, bytes, 0, 8192);
+          let n =
+            switch (Unix.read(pipe, bytes, 0, 8192)) {
+            | exception _ =>
+              isReading := false;
+              0;
+            | v => v
+            };
 
           if (n > 0) {
             let sub = Bytes.sub(bytes, 0, n);

--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -169,6 +169,10 @@ let _spawn =
           ? Sys.sigkill  /* Sigkill is the only signal supported on Win by the Unix module */
           : sig_;
 
+      Unix.close(stdin);
+      Unix.close(stdout);
+      Unix.close(stderr);
+
       /* In some cases, we get a Unix_error(Unix.ESRCH, "kill") exception thrown */
       /* For now - just ignore. Is there a case where the consumer needs to know / handle this? */
       switch (Unix.kill(pid, signalToUse)) {

--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -93,6 +93,8 @@ let createReadingThread = (pipe, pipe_onData, isRunning) =>
           };
         };
       };
+
+      _safeClose(pipe);
     },
     (pipe, pipe_onData),
   );
@@ -145,10 +147,10 @@ let _spawn =
   let _dispose = exitCode => {
     isRunning := false;
     Event.dispatch(onClose, exitCode);
-
-    _safeClose(stdout);
     _safeClose(stdin);
-    _safeClose(stderr);
+
+    /*_safeClose(stdout);
+    _safeClose(stderr);*/
     Gc.full_major();
   };
 


### PR DESCRIPTION
When debugging the `ripgrep` integration in Onivim, I noticed that sometimes the output would be truncated. I tracked it down to here - closing the pipes too early after the child process has stopped. We should let the pipes flush and then close / remove the reference when reading is complete.